### PR TITLE
Daniele had code to drop SIMT loops of 1 iteration. This messes up th…

### DIFF
--- a/spl.gi
+++ b/spl.gi
@@ -10,7 +10,7 @@ Class(SIMTTensor, Tensor, rec(
         Constraint(IsList(arg) and Length(arg) >= 2);
         simt_dim := arg[1];
         L := arg{[2..Length(arg)]};
-        L:=Filtered(L,x->x<>I(1));
+#        L:=Filtered(L,x->x<>I(1));
         if (Length(L)=0) then return I(1); fi;
         if Length(L)=1 then return L[1]; fi;
 

--- a/sumsgen.gi
+++ b/sumsgen.gi
@@ -64,13 +64,13 @@ Class(SIMTSumsGen, DefaultSumsGen, rec(
                         self(ch[i], opts) *
                     Gath(o.gathTensor(i)(Filtered([j1b, fId(bkcols), j2b], x->x<>0)));
             
-                if j2.range <> 1 then
+#                if j2.range <> 1 then
                     term := SIMTISum(o.simt_dim, j2, j2.range, term); 
-                fi;
+#                fi;
             
-                if j1.range <> 1 then
+#                if j1.range <> 1 then
                     term := SIMTISum(o.simt_dim, j1, j1.range, term); 
-                fi;
+#                fi;
             
                 Add(prod, term);
             fi;


### PR DESCRIPTION
…e synchronization hierarchy. Disabled all itnum==1 special cases. If they need to be handled we should add a rewrite rule to drop loops of 1 iteration and substitute loopvar->V(0) into the body.